### PR TITLE
Fix LDAP search base handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ for searching the directory.
 
 Required environment variables:
 - `LDAP_SERVER`: LDAP server address
-- `LDAP_BASE_DN`: Base DN for LDAP searches
+- `LDAP_BASE_DN`: Base DN for LDAP searches. This should reference the part of the directory tree where user accounts are stored (e.g. `DC=example,DC=com`). Providing a group-specific OU will prevent user objects from being located.
 - `LDAP_AUTH_SECRET`: Secret key for JWT token signing
 
 Optional:

--- a/api/authentication.py
+++ b/api/authentication.py
@@ -117,10 +117,12 @@ def ldap_login():
             return abort(401)
             
         # Re-search to get all user attributes
+        # Retrieve user attributes using a BASE scope on the exact DN to avoid
+        # failures when LDAP_BASE_DN does not contain the user's full path
         connection.search(
-            search_base=os.getenv('LDAP_BASE_DN'),
-            search_filter=f'(distinguishedName={user_dn})',
-            search_scope=search_scope,
+            search_base=user_dn,
+            search_filter='(objectClass=*)',
+            search_scope=BASE,
             attributes=['objectGUID', 'givenName', 'sn', 'mail', 'memberOf']
         )
     else:

--- a/docs/src/install-guide/docker.md
+++ b/docs/src/install-guide/docker.md
@@ -112,7 +112,7 @@ available for configuration in such an environment:
 
 `LDAP_SERVER`: The complete path to the LDAP server including the protocol (`ldap` or `ldaps`) and port number.
 
-`LDAP_BASE_DN`: Defines the base distinguished name used to search for users.
+`LDAP_BASE_DN`: Defines the base distinguished name used to search for users. This should be the DN where user objects reside (for example `DC=example,DC=com`). Using a group OU will prevent users from being found.
 
 `LDAP_AUTH_SECRET`: After successfully authenticating using LDAP, sessions are authenticated using a signed JWT token and this defines
 the secret for that token.


### PR DESCRIPTION
## Summary
- adjust service account search to scope on user DN
- document requirement for LDAP_BASE_DN to point at user DN

## Testing
- `pip install pytest` *(fails: Could not find a version that satisfies the requirement pytest)*